### PR TITLE
Add ability to choose which metrics to collect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10.1
+FROM alpine:3.13.5
 MAINTAINER support@neuvector.com
 
 RUN apk add --no-cache python3 && \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ $ sudo pip3 install prometheus_client requests
 #### To run the exporter and prometheus as a container
 It's easier to start NeuVector exporter as a container. The following section describe how to start the exporter in the Docker environment. A kubernetes sample yaml file, nv_exporter.yml, is also included.
 
-Modify both docker-compose.yml and nv_exporter.yml. Specify NeuVector controller's RESTful API endpoint `CTRL_API_SERVICE`, login username `CTRL_USERNAME`, password `CTRL_PASSWORD`, and the port that the export listens on through environment variables `EXPORTER_PORT`. **It's highly recommanded to create a read-only user account for the exporter.**
+Modify both docker-compose.yml and nv_exporter.yml. Specify NeuVector controller's RESTful API endpoint `CTRL_API_SERVICE`, login username `CTRL_USERNAME`, password `CTRL_PASSWORD`, and the port that the export listens on through environment variables `EXPORTER_PORT`. Optionally, you can also specify `EXPORTER_METRICS` to a comma-separated list of metric groups to collect and export. **It's highly recommanded to create a read-only user account for the exporter.**
+
+Metric groups:
+- `summary` - overall NeuVector status
+- `conversation` - total bytes for every conversation between workloads
+- `enforcer` - enforcer CPU and memory usage
+- `host` - host memory usage
+- `admission` - number of allowed and denied Kubernetes admission requests
+- `image_vulnerability` - number of high and medium vulnerabilities for every scanned registry image
+- `container_vulnerability` - number of high and medium vulnerabilities for every service, reporting a single pod's status per service (excluding service mesh sidecars)
+- `log` - data for the latest threat, incident, and violation logs (latest 5 logs each)
 
 
 ##### In native docker environment

--- a/nv_dashboard.json
+++ b/nv_dashboard.json
@@ -1340,7 +1340,7 @@
           "format": "time_series",
           "instant": false,
           "intervalFactor": 2,
-          "legendFormat": "<font color=\"red\">{{name}}</font><br/>{{fromname}}<br/>{{toname}}",
+          "legendFormat": "<font color=\"red\">{{name}}</font><br/>{{fromname}}<br/>-> {{toname}}",
           "refId": "A"
         }
       ],

--- a/nv_exporter.py
+++ b/nv_exporter.py
@@ -141,7 +141,7 @@ class apiCollector(object):
                     port_exists = True
                 if port_exists is True:
                     for k in c['ports']:
-                        if c['bytes'] is not 0:
+                        if c['bytes'] != 0:
                             metric.add_sample('nv_conversation_bytes',
                                               value=c['bytes'],
                                               labels={
@@ -273,13 +273,17 @@ class apiCollector(object):
             ttimelist = []
             tnamelist = []
             tcnamelist = []
+            tcnslist = []
             tsnamelist = []
+            tsnslist = []
             tidlist = []
             for c in json.loads(response.text)['threats']:
                 ttimelist.append(c['reported_timestamp'])
                 tnamelist.append(c['name'])
                 tcnamelist.append(c['client_workload_name'])
+                tcnslist.append(c['client_workload_domain'] if 'client_workload_domain' in c else "")
                 tsnamelist.append(c['server_workload_name'])
+                tsnslist.append(c['server_workload_domain'] if 'server_workload_domain' in c else "")
                 tidlist.append(c['id'])
             for x in range(0, min(5, len(tidlist))):
                 metric.add_sample('nv_log_events',
@@ -287,7 +291,9 @@ class apiCollector(object):
                                   labels={
                                       'log': "thread",
                                       'fromname': tcnamelist[x],
-                                      'toname': " -> " + tsnamelist[x],
+                                      'fromns': tcnslist[x],
+                                      'toname': tsnamelist[x],
+                                      'tons': tsnamelist[x],
                                       'id': tidlist[x],
                                       'name': tnamelist[x],
                                       'target': ep
@@ -300,12 +306,14 @@ class apiCollector(object):
             itimelist = []
             inamelist = []
             iwnamelist = []
+            iwnslist = []
             iidlist = []
             for c in json.loads(response.text)['incidents']:
                 if 'workload_name' in c:
                     itimelist.append(c['reported_timestamp'])
                     inamelist.append(c['name'])
                     iwnamelist.append(c['workload_name'])
+                    iwnslist.append(c['workload_domain'] if 'workload_domain' in c else "")
                     iidlist.append(c['workload_id'])
             for x in range(0, min(5, len(iidlist))):
                 metric.add_sample('nv_log_events',
@@ -313,7 +321,9 @@ class apiCollector(object):
                                   labels={
                                       'log': "incident",
                                       'fromname': iwnamelist[x],
+                                      'fromns': iwnslist[x],
                                       'toname': " ",
+                                      'tons': " ",
                                       'name': inamelist[x],
                                       'id': iidlist[x],
                                       'target': ep
@@ -326,13 +336,17 @@ class apiCollector(object):
             vtimelist = []
             vnamelist = []
             vcnamelist = []
+            vcnslist = []
             vsnamelist = []
+            vsnslist = []
             vidlist = []
             for c in json.loads(response.text)['violations']:
                 vtimelist.append(c['reported_timestamp'])
                 vcnamelist.append(c['client_name'])
+                vcnslist.append(c['client_domain'] if 'client_domain' in c else "")
                 vnamelist.append("Network Violation")
                 vsnamelist.append(c['server_name'])
+                vsnslist.append(c['server_domain'] if 'server_domain' in c else "")
                 vidlist.append(c['client_id'] + c['server_id'])
             for x in range(0, min(5, len(vidlist))):
                 metric.add_sample('nv_log_events',
@@ -340,8 +354,10 @@ class apiCollector(object):
                                   labels={
                                       'log': "violation",
                                       'id': vidlist[x],
-                                      'toname': " -> " + vsnamelist[x],
                                       'fromname': vcnamelist[x],
+                                      'fromns': vcnslist[x],
+                                      'toname': vsnamelist[x],
+                                      'tons': vsnslist[x],
                                       'name': vnamelist[x],
                                       'target': ep
                                   })

--- a/nv_exporter.yml
+++ b/nv_exporter.yml
@@ -38,4 +38,6 @@ spec:
               value: admin
             - name: EXPORTER_PORT
               value: "8068"
+            # - name: EXPORTER_METRICS
+            #   value: summary,conversation,enforcer,host,admission,image_vulnerability,container_vulnerability,log
       restartPolicy: Always


### PR DESCRIPTION
I noticed @becitsthere had an unmerged commit to support namespace info in log events, which I would also prefer over omitting the namespace info, so I forked off of that.

I added a `--collect-metrics` argument and matching `EXPORTER_METRICS` environment variable that allows a user to choose which metrics groups are computed and reported. We have a large NeuVector deployment, so reporting metrics for every conversation would be expensive, and we currently don't require that information. This idea was loosely based on how [prometheus/node_exporter](https://github.com/prometheus/node_exporter) works.