### PR TITLE
Added the ENFORCER_STATS environment variable in the nv_exporter.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Variable | Description | Default
 `CTRL_USERNAME` | Username to login to controller REST API service | `admin`
 `CTRL_PASSWORD` | Password to login to controller REST API service | `admin`
 `EXPORTER_PORT` | The port that the export is listening on | `nil`
-`ENFORCER_STATS` | For the performance reason, by default the exporter does NOT pull CPU/memory usage from enforcers. Enable this if you want to see the metrix in the dashboard | `0`
+`ENFORCER_STATS` | For the performance reason, by default the exporter does NOT pull CPU/memory usage from enforcers. Enable this if you want to see the metrics in the dashboard | `0`
 
 ##### In native docker environment
 

--- a/nv_exporter.yml
+++ b/nv_exporter.yml
@@ -43,4 +43,6 @@ spec:
               value: "8068"
             # - name: EXPORTER_METRICS
             #   value: summary,conversation,enforcer,host,admission,image_vulnerability,container_vulnerability,log
+            # - name: ENFORCER_STATS
+            #   value: "true"
       restartPolicy: Always

--- a/nv_exporter_secret.yaml
+++ b/nv_exporter_secret.yaml
@@ -69,4 +69,8 @@ spec:
           #     value: admin
           #   - name: EXPORTER_PORT
           #     value: "8068"
+          #   - name: EXPORTER_METRICS
+          #     value: summary,conversation,enforcer,host,admission,image_vulnerability,container_vulnerability,log
+          #   - name: ENFORCER_STATS
+          #     value: "true"
       restartPolicy: Always


### PR DESCRIPTION
It may be clearer and more intuitive to enable Enforcer metrics if the environment variable is already described in the YAML manifest.