### PR TITLE
chore: threats metric typo

### DIFF
--- a/nv_exporter.py
+++ b/nv_exporter.py
@@ -319,7 +319,7 @@ class apiCollector(object):
                 metric.add_sample('nv_log_events',
                                   value=ttimelist[x] * 1000,
                                   labels={
-                                      'log': "thread",
+                                      'log': "threat",
                                       'fromname': tcnamelist[x],
                                       'fromns': tcnslist[x],
                                       'toname': tsnamelist[x],


### PR DESCRIPTION
Fixing a typo present in the threats metric which can be seen in the grafana dashboard