### PR TITLE
Avoid KeyError if workload_domain is missing

### DIFF
--- a/nv_exporter.py
+++ b/nv_exporter.py
@@ -452,7 +452,7 @@ class NVApiCollector:
                 if 'workload_name' in c:
                     iwnamelist.append(c['workload_name'])
                     iclusterlist.append(c['cluster_name'])
-                    iwnslist.append(c['workload_domain'])
+                    iwnslist.append(c['workload_domain'] if 'workload_domain' in c else "")
                     iwidlist.append(c['workload_id'])
                 else:
                     iwnamelist.append("")


### PR DESCRIPTION
This PR updates the logic to append an empty string when the workload_domain key is missing from the context dictionary, avoiding potential KeyError exceptions during list population.

Should solve [neuvector/neuvector-helm#482](https://github.com/neuvector/neuvector-helm/issues/482)