### PR TITLE
NVSHAS-10027: Error: name 'vcidlist' is not defined after upgrading t…

### DIFF
--- a/nv_exporter.py
+++ b/nv_exporter.py
@@ -489,6 +489,7 @@ class NVApiCollector:
             vnamelist = []
             vcnamelist = []
             vcnslist = []
+            vcidlist = []
             vsnamelist = []
             vsnslist = []
             vidlist = []


### PR DESCRIPTION
…o latest prometheus-exporter