### PR TITLE
fix: pin rancher-eio/read-vault-secrets to new SHA

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -20,7 +20,7 @@ jobs:
     # The FOSSA token is shared between all repos in NeuVector's GH org. It can
     # be used directly and there is no need to request specific access to EIO.
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
       with:
         secrets: |
           secret/data/github/org/neuvector/fossa/credentials token | FOSSA_API_KEY_PUSH_ONLY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     - name: Load Secrets from Vault
-      uses: rancher-eio/read-vault-secrets@0da85151ad1f19ed7986c41587e45aac1ace74b6 # v3
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # v3
       with:
         secrets: |
           secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | RANCHER_DOCKER_USERNAME ;


### PR DESCRIPTION
Update rancher-eio/read-vault-secrets from 0da85151ad1f19ed7986c41587e45aac1ace74b6 to 7282bf97898cd1c16c89f837e0bb442e6d384c89 (v3) to comply with NV org policy requiring full-length commit SHA.